### PR TITLE
Feat 526

### DIFF
--- a/packages/apollo-angular-link-http-common/src/utils.ts
+++ b/packages/apollo-angular-link-http-common/src/utils.ts
@@ -103,7 +103,7 @@ export const fetch = (
   const observe = req.options.reportProgress ? 'events' : 'response';
 
   // create a request
-  return httpClient.request<Object>(req.method, req.url, {
+  return httpClient.request(req.method, req.url, {
     observe,
     responseType: 'json',
     ...bodyOrParams,

--- a/packages/apollo-angular-link-http/src/HttpLink.ts
+++ b/packages/apollo-angular-link-http/src/HttpLink.ts
@@ -44,6 +44,7 @@ export class HttpLinkHandler extends ApolloLink {
         const url = pick('uri', 'graphql');
         const withCredentials = pick('withCredentials');
         const useMultipart = pick('useMultipart');
+        const reportProgress = pick('reportProgress', false);
 
         const req: Request = {
           method,
@@ -55,8 +56,8 @@ export class HttpLinkHandler extends ApolloLink {
           options: {
             withCredentials,
             useMultipart,
+            reportProgress,
             headers: this.options.headers,
-            reportProgress: this.options.reportProgress || false,
           },
         };
 


### PR DESCRIPTION
```ts
pick('reportProgress', false)
```

means it prioritize `reportProgress` from operation's context over global the settings and it is `false` by default.

What's operation context? When you use Apollo.watchQuery (or query) you can define a `context` there, which is an object. If you put there `reportProgress` it will pick it up and use it instead of the global setting.